### PR TITLE
Fix vercel dev recursion: remove dev script from package.json

### DIFF
--- a/PROJECT_REPORT.md
+++ b/PROJECT_REPORT.md
@@ -205,7 +205,7 @@ flask-cors     # korrekt
 - [x] `flask-wtf` / `wtforms` bereits in Phase 1 entfernt – kein Handlungsbedarf
 - [x] jQuery-CDN und Webflow-Script aus `index.html` entfernt (beide ungenutzt)
 - [x] Fehlerbehandlung verfeinert: Server-Fehler werden abgefangen, benutzerfreundliche deutsche Fehlermeldungen zurückgegeben (`app.py`, `main.js`)
-- [x] **Bugfix:** `vercel dev` Recursive-Invocation-Error behoben – `"dev"` Script in `package.json` zeigt jetzt auf `python api/app.py` statt `vercel dev`
+- [x] **Bugfix:** `vercel dev` Recursive-Invocation-Error behoben – `"dev"` Script aus `package.json` entfernt. `vercel dev` direkt im Terminal aufrufen; ein `dev`-Script ist für dieses serverless Python-Projekt nicht sinnvoll.
 
 ### Phase 3 – Feature-Erweiterungen
 > Geplante Verbesserungen und neue Features

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "python api/app.py",
     "deploy": "vercel --prod",
     "preview": "vercel"
   },


### PR DESCRIPTION
Running 'vercel dev' looks for a dev script in package.json to start a framework server. Having that script call 'vercel dev' causes recursion, and pointing it to 'python api/app.py' fails because Flask is not in the Node environment. The correct fix for a serverless Python project is to remove the dev script entirely and call 'vercel dev' directly.