### PR TITLE
Fix Vercel 500: add sys.path for module imports in serverless context

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,9 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 from flask import Flask, render_template, request, jsonify, redirect, session
 from flask_cors import CORS
-import os
 
 from config import SECRET_KEY, CORS_ORIGINS, SONGS_MAP, MAX_ARTISTS, MAX_ARTIST_NAME_LENGTH
 from spotify_service import get_oauth, refresh_token_if_needed, build_playlist

--- a/api/spotify_service.py
+++ b/api/spotify_service.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 from config import SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, REDIRECT_URI


### PR DESCRIPTION
Vercel sets cwd to project root, not api/. Bare imports like 'from config import ...' fail with ModuleNotFoundError at runtime. Prepend the file's own directory to sys.path in app.py and spotify_service.py so config.py and spotify_service.py are always found.