### PR TITLE
Fix Vercel 500: remove api/__init__.py, fix static paths

### DIFF
--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -2,9 +2,9 @@
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
-    <link rel="shortcut icon" href="../static/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/static/favicon.ico" type="image/x-icon">
     <title>PlayChoon - Spotify Playlist Generator</title>
-    <link rel="stylesheet" href="../static/style.css" />
+    <link rel="stylesheet" href="/static/style.css" />
   </head>
   <body class="body">
     <div class="container w-container">
@@ -86,6 +86,6 @@
         </div>
       </div>
     </div>
-    <script src="../static/main.js"></script>
+    <script src="/static/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
api/__init__.py made Python treat api/ as a package, breaking module imports at runtime on Vercel (FUNCTION_INVOCATION_FAILED). Without it, sys.path.insert in app.py correctly resolves config and spotify_service.

Also revert ../static/ paths in index.html back to /static/ – Flask serves static files at the /static/ URL regardless of template location.